### PR TITLE
Create 0xB36B62929762ACF8A9Cc27ECebF6D353eBB48244.json

### DIFF
--- a/tokens/0xB36B62929762ACF8A9Cc27ECebF6D353eBB48244.json
+++ b/tokens/0xB36B62929762ACF8A9Cc27ECebF6D353eBB48244.json
@@ -1,0 +1,14 @@
+{
+  "symbol": "SHARP",
+  "name": "SHARP",
+  "address": "0xB36B62929762ACF8A9Cc27ECebF6D353eBB48244",
+  "decimals": 18,
+  "website": "https://sharpeconomy.org/",
+  "github": "https://github.com/SharpEconomy",
+  "community": [
+    "https://x.com/SharpEconomy",
+    "https://t.me/SharpEconomy",
+    "https://discord.gg/sharpeconomy",
+    "https://www.linkedin.com/company/sharpeconomy/"
+  ]
+}


### PR DESCRIPTION
The token is only compatible with Polygon PoS (chainId 137). No Ethereum-mainnet contract, so no Etherscan URL applies.

Polygonscan reference: https://polygonscan.com/token/0xb36b62929762acf8a9cc27ecebf6d353ebb48244.

File placed per repo README: single JSON named by the contract address in ERC-55 checksum under tokens/ with required fields (symbol, name, address, decimals). Optional fields follow README (website, GitHub, community).

For context, prior PR #965 used tokens/eth/…, which targets Ethereum-mainnet and prompted the Etherscan request. This PR corrects the path and chain clarification